### PR TITLE
Alterar senha diretamente para usuário logado 

### DIFF
--- a/flutter_client/lib/modules/presentation/pages/password_recovery/change_password_page/change_password_controller.dart
+++ b/flutter_client/lib/modules/presentation/pages/password_recovery/change_password_page/change_password_controller.dart
@@ -1,5 +1,6 @@
 //feito por marcelo
 import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:mobx/mobx.dart';
 
 part 'change_password_controller.g.dart';
@@ -112,6 +113,25 @@ abstract class _ChangePasswordControllerBase with Store {
       return 'Nao foi possivel redefinir a senha.';
     } catch (_) {
       return 'Nao foi possivel redefinir a senha.';
+    }
+  }
+
+  // Feito por Abdallah - RA: 25018711
+  Future<String?> changePasswordLoggedIn() async {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
+        return 'Usuario nao autenticado.';
+      }
+      await user.updatePassword(password);
+      return null;
+    } on FirebaseAuthException catch (error) {
+      if (error.code == 'requires-recent-login') {
+        return 'Por seguranca, voce precisa fazer login novamente antes de alterar a senha.';
+      }
+      return error.message ?? 'Nao foi possivel alterar a senha.';
+    } catch (_) {
+      return 'Nao foi possivel alterar a senha.';
     }
   }
 }

--- a/flutter_client/lib/modules/presentation/pages/password_recovery/change_password_page/change_password_page.dart
+++ b/flutter_client/lib/modules/presentation/pages/password_recovery/change_password_page/change_password_page.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_client/modules/presentation/components/auth/auth_action_button.dart';
 import 'package:flutter_client/modules/presentation/components/auth/auth_input_field.dart';
@@ -49,7 +50,11 @@ class _ChangePasswordPageState extends State<ChangePasswordPage> {
       return;
     }
 
-    if (email.isEmpty || code.isEmpty) {
+    // Feito por Abdallah - RA: 25018711
+    final currentUser = FirebaseAuth.instance.currentUser;
+    final isLoggedIn = currentUser != null;
+
+    if (!isLoggedIn && (email.isEmpty || code.isEmpty)) {
       setState(() {
         statusMessage = 'Solicite um novo codigo para continuar.';
         isStatusError = true;
@@ -62,7 +67,14 @@ class _ChangePasswordPageState extends State<ChangePasswordPage> {
       statusMessage = null;
       isStatusError = false;
     });
-    final error = await controller.resetPassword(email: email, code: code);
+
+    final String? error;
+    if (isLoggedIn) {
+      error = await controller.changePasswordLoggedIn();
+    } else {
+      error = await controller.resetPassword(email: email, code: code);
+    }
+
     if (!mounted) {
       return;
     }
@@ -78,7 +90,7 @@ class _ChangePasswordPageState extends State<ChangePasswordPage> {
     }
 
     setState(() {
-      statusMessage = 'Senha redefinida com sucesso.';
+      statusMessage = isLoggedIn ? 'Senha alterada com sucesso.' : 'Senha redefinida com sucesso.';
       isStatusError = false;
     });
 
@@ -87,7 +99,11 @@ class _ChangePasswordPageState extends State<ChangePasswordPage> {
       return;
     }
 
-    Modular.to.navigate(AppRoutes.login);
+    if (isLoggedIn) {
+      Modular.to.pop();
+    } else {
+      Modular.to.navigate(AppRoutes.login);
+    }
   }
 
   @override


### PR DESCRIPTION
Implementar a funcionalidade que permite ao usuário já autenticado alterar a sua senha diretamente a partir da tela de configurações, eliminando a necessidade de inserção de código de verificação enviado por e‑mail.

Principais alterações

change_password_controller.dart
Importado package:firebase_auth/firebase_auth.dart.
Implementado o método Future<String?> changePasswordLoggedIn() que usa FirebaseAuth.instance.currentUser.updatePassword(...).
Tratamento de erros, incluindo o caso requires-recent-login.
change_password_page.dart
Detecta se há usuário logado (FirebaseAuth.instance.currentUser).
Quando logado, chama controller.changePasswordLoggedIn() ao submeter o formulário.
Mensagens de sucesso/erro ajustadas para o fluxo de alteração direta.
Navegação de volta (Modular.to.pop()) após alteração bem‑sucedida.
Impacto

