### PR TITLE
autenticação multifator (MFA) por e-mail no login

### DIFF
--- a/flutter_client/lib/app_module.dart
+++ b/flutter_client/lib/app_module.dart
@@ -9,6 +9,7 @@ import 'package:flutter_client/modules/presentation/pages/login_page/login_contr
 import 'package:flutter_client/modules/presentation/pages/login_page/login_page.dart';
 import 'package:flutter_client/modules/presentation/pages/marketplace_page/marketplace_controller.dart';
 import 'package:flutter_client/modules/presentation/pages/marketplace_page/marketplace_page.dart';
+import 'package:flutter_client/modules/presentation/pages/mfa_verification_page/mfa_verification_page.dart';
 import 'package:flutter_client/modules/presentation/pages/password_recovery/change_password_page/change_password_controller.dart';
 import 'package:flutter_client/modules/presentation/pages/password_recovery/change_password_page/change_password_page.dart';
 import 'package:flutter_client/modules/presentation/pages/password_recovery/forgot_password_page/forgot_password_page.dart';
@@ -50,6 +51,7 @@ class AppModule extends Module {
     r.child(AppRoutes.register, child: (_) => const RegisterPage());
     r.child(AppRoutes.forgotPassword, child: (_) => const ForgotPasswordPage());
     r.child(AppRoutes.changePassword, child: (_) => const ChangePasswordPage());
+    r.child(AppRoutes.mfaVerify, child: (_) => const MfaVerificationPage());
     r.child(AppRoutes.allInvestments, child: (_) => const AllInvestmentsPage());
     r.child(AppRoutes.marketplace, child: (_) => const MarketplacePage());
     r.child(

--- a/flutter_client/lib/modules/presentation/pages/login_page/login_page.dart
+++ b/flutter_client/lib/modules/presentation/pages/login_page/login_page.dart
@@ -1,4 +1,6 @@
 //feito por abdallah, gabriel e marcelo
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_client/modules/presentation/components/auth/auth_action_button.dart';
@@ -22,15 +24,85 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage> {
   final LoginController controller = Modular.get<LoginController>();
 
+  void _showSnack(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  String _parseApiMessage(dynamic data, {required String fallback}) {
+    if (data is Map) {
+      final message = data['message'];
+      if (message is String && message.trim().isNotEmpty) {
+        return message;
+      }
+    }
+    return fallback;
+  }
+
   Future<void> _handleLogin() async {
     final success = await controller.login();
     if (!mounted || !success) {
       return;
     }
 
-    // Força o reload do HomeController para o novo usuário —
-    // necessário porque o _HomePageState é singleton e o initState
-    // não é chamado de novo ao navegar de volta para /home
+    // A partir daqui o usuario ja autenticou no FirebaseAuth.
+    // Antes de liberar acesso ao app, consultamos o backend para saber se o
+    // MFA esta habilitado; se estiver, exigimos o codigo enviado por e-mail.
+    final user = FirebaseAuth.instance.currentUser;
+    final token = await user?.getIdToken();
+
+    if (!mounted) return;
+
+    if (token == null) {
+      await FirebaseAuth.instance.signOut();
+      if (!mounted) return;
+      _showSnack('Nao foi possivel validar sua sessao. Tente novamente.');
+      return;
+    }
+
+    final dio = Modular.get<Dio>();
+
+    try {
+      // Consulta o status do MFA no backend (Firestore).
+      final response = await dio.get(
+        '/mfa/status',
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+
+      final data = response.data;
+      final enabled = data is Map ? data['enabled'] == true : false;
+
+      if (enabled) {
+        // Dispara o envio do codigo para o e-mail cadastrado e navega para a tela
+        // de verificacao. O usuario so entra na home apos confirmar o codigo.
+        await dio.post(
+          '/mfa/request-code',
+          options: Options(headers: {'Authorization': 'Bearer $token'}),
+        );
+
+        if (!mounted) return;
+        Modular.to.navigate(AppRoutes.mfaVerify);
+        return;
+      }
+    } on DioException catch (e) {
+      final message = _parseApiMessage(
+        e.response?.data,
+        fallback: 'Erro ao verificar autenticacao em duas etapas.',
+      );
+      // Falhou em checar/solicitar MFA: faz logout para evitar acesso sem validacao.
+      await FirebaseAuth.instance.signOut();
+      if (!mounted) return;
+      _showSnack(message);
+      return;
+    } catch (_) {
+      // Mesmo comportamento para erros nao esperados.
+      await FirebaseAuth.instance.signOut();
+      if (!mounted) return;
+      _showSnack('Erro ao verificar autenticacao em duas etapas.');
+      return;
+    }
+
     Modular.get<HomeController>().load();
     Modular.to.navigate(AppRoutes.home);
   }

--- a/flutter_client/lib/modules/presentation/pages/mfa_verification_page/mfa_verification_controller.dart
+++ b/flutter_client/lib/modules/presentation/pages/mfa_verification_page/mfa_verification_controller.dart
@@ -1,0 +1,127 @@
+// feito por Abdallah
+// RA: 25018711
+
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+
+class MfaVerificationController extends ChangeNotifier {
+  MfaVerificationController(
+    this._dio, [
+    FirebaseAuth? auth,
+  ]) : _auth = auth ?? FirebaseAuth.instance;
+
+  final Dio _dio;
+  final FirebaseAuth _auth;
+
+  String code = '';
+  bool isLoading = false;
+  String? errorMessage;
+
+  bool get isCodeValid => code.trim().length == 6;
+
+  void setCode(String value) {
+    code = value;
+    errorMessage = null;
+    notifyListeners();
+  }
+
+  Future<String?> _getIdToken() async {
+    final user = _auth.currentUser;
+    if (user == null) {
+      return null;
+    }
+    return user.getIdToken();
+  }
+
+  String _parseApiMessage(dynamic data, {required String fallback}) {
+    if (data is Map) {
+      final message = data['message'];
+      if (message is String && message.trim().isNotEmpty) {
+        return message;
+      }
+    }
+    return fallback;
+  }
+
+  Future<bool> resendCode() async {
+    final token = await _getIdToken();
+    if (token == null) {
+      errorMessage = 'Sessao expirada. Faca login novamente.';
+      notifyListeners();
+      return false;
+    }
+
+    // Reenvia um novo codigo para o e-mail (backend gera e substitui o anterior).
+    isLoading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      await _dio.post(
+        '/mfa/request-code',
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+      return true;
+    } on DioException catch (e) {
+      errorMessage = _parseApiMessage(
+        e.response?.data,
+        fallback: 'Nao foi possivel reenviar o codigo.',
+      );
+      return false;
+    } catch (_) {
+      errorMessage = 'Nao foi possivel reenviar o codigo.';
+      return false;
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> verifyCode() async {
+    final token = await _getIdToken();
+    if (token == null) {
+      errorMessage = 'Sessao expirada. Faca login novamente.';
+      notifyListeners();
+      return false;
+    }
+
+    final normalizedCode = code.trim();
+    if (normalizedCode.length != 6) {
+      errorMessage = 'Informe o codigo de 6 digitos.';
+      notifyListeners();
+      return false;
+    }
+
+    isLoading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      // Valida o codigo no backend. Em caso de sucesso, o app libera a navegacao
+      // para a home; em caso de erro, o backend pode retornar mensagem detalhada.
+      await _dio.post(
+        '/mfa/verify-code',
+        data: {'code': normalizedCode},
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+      return true;
+    } on DioException catch (e) {
+      errorMessage = _parseApiMessage(
+        e.response?.data,
+        fallback: 'Codigo invalido ou expirado.',
+      );
+      return false;
+    } catch (_) {
+      errorMessage = 'Codigo invalido ou expirado.';
+      return false;
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> signOut() async {
+    await _auth.signOut();
+  }
+}

--- a/flutter_client/lib/modules/presentation/pages/mfa_verification_page/mfa_verification_page.dart
+++ b/flutter_client/lib/modules/presentation/pages/mfa_verification_page/mfa_verification_page.dart
@@ -1,0 +1,170 @@
+// feito por Abdallah
+// RA: 25018711
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_client/modules/presentation/components/auth/auth_action_button.dart';
+import 'package:flutter_client/modules/presentation/components/auth/auth_input_field.dart';
+import 'package:flutter_client/modules/presentation/components/auth/auth_page_scaffold.dart';
+import 'package:flutter_client/modules/presentation/components/auth/auth_section_header.dart';
+import 'package:flutter_client/modules/presentation/pages/home_page/home_controller.dart';
+import 'package:flutter_client/modules/presentation/pages/mfa_verification_page/mfa_verification_controller.dart';
+import 'package:flutter_client/shared/app_routes.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+class MfaVerificationPage extends StatefulWidget {
+  const MfaVerificationPage({super.key});
+
+  @override
+  State<MfaVerificationPage> createState() => _MfaVerificationPageState();
+}
+
+class _MfaVerificationPageState extends State<MfaVerificationPage> {
+  late final MfaVerificationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = MfaVerificationController(Modular.get<Dio>());
+    _controller.addListener(_refresh);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_refresh);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _refresh() {
+    if (mounted) setState(() {});
+  }
+
+  void _showSnack(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  Future<void> _onVerify() async {
+    final success = await _controller.verifyCode();
+    if (!mounted) return;
+
+    if (!success) {
+      return;
+    }
+
+    Modular.get<HomeController>().load();
+    Modular.to.navigate(AppRoutes.home);
+  }
+
+  Future<void> _onResend() async {
+    final success = await _controller.resendCode();
+    if (!mounted) return;
+
+    _showSnack(
+      success ? 'Codigo reenviado.' : (_controller.errorMessage ?? 'Erro ao reenviar codigo.'),
+    );
+  }
+
+  Future<void> _onSignOut() async {
+    await _controller.signOut();
+    if (!mounted) return;
+    Modular.to.navigate(AppRoutes.login);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AuthPageScaffold(
+      backgroundColor: const Color(0xFFFCF8FF),
+      showDecorations: true,
+      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Center(
+            child: Text(
+              'MesclaInvest',
+              style: TextStyle(
+                color: Color(0xFF170B58),
+                fontSize: 30,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 64),
+          const AuthSectionHeader(
+            title: 'Verifique seu login',
+            subtitle: 'Enviamos um codigo de 6 digitos\npara seu e-mail.',
+            titleColor: Color(0xFF170B58),
+            subtitleColor: Color(0xFF584048),
+            titleFontSize: 34,
+            bottomSpacing: 32,
+          ),
+          AuthInputField(
+            label: 'CODIGO',
+            hint: '000000',
+            keyboardType: TextInputType.number,
+            onChanged: _controller.setCode,
+            maxLength: 6,
+            textAlign: TextAlign.center,
+            inputFormatters: [
+              FilteringTextInputFormatter.digitsOnly,
+              LengthLimitingTextInputFormatter(6),
+            ],
+          ),
+          if (_controller.errorMessage != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: Text(
+                _controller.errorMessage!,
+                style: const TextStyle(color: Colors.red, fontSize: 14),
+              ),
+            ),
+          AuthActionButton(
+            label: 'Confirmar codigo',
+            onPressed: _onVerify,
+            isEnabled: _controller.isCodeValid,
+            isLoading: _controller.isLoading,
+            gradientColors: const [
+              Color(0xFFD4147A),
+              Color(0xFFAE1465),
+            ],
+            disabledGradientColors: const [
+              Color(0xFFE4B3CF),
+              Color(0xFFD4B1C6),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Center(
+            child: TextButton(
+              onPressed: _controller.isLoading ? null : _onResend,
+              style: TextButton.styleFrom(
+                foregroundColor: const Color(0xFFC71E74),
+              ),
+              child: const Text(
+                'Reenviar codigo',
+                style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Center(
+            child: TextButton(
+              onPressed: _controller.isLoading ? null : _onSignOut,
+              style: TextButton.styleFrom(
+                foregroundColor: const Color(0xFF584048),
+              ),
+              child: const Text(
+                'Sair',
+                style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+          const SizedBox(height: 32),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/modules/presentation/pages/settings_page/settings_controller.dart
+++ b/flutter_client/lib/modules/presentation/pages/settings_page/settings_controller.dart
@@ -30,6 +30,9 @@ class SettingsController extends ChangeNotifier {
   bool isUploadingPhoto = false;
   String? _firestoreName;
 
+  bool mfaEnabled = false;
+  bool isUpdatingMfa = false;
+
   User? get currentUser => _auth.currentUser;
 
   String get userLabel {
@@ -54,6 +57,16 @@ class SettingsController extends ChangeNotifier {
   }
 
   ImageProvider? get profileImage => _homeController.profileImage;
+
+  String _parseApiMessage(dynamic data, {required String fallback}) {
+    if (data is Map) {
+      final message = data['message'];
+      if (message is String && message.trim().isNotEmpty) {
+        return message;
+      }
+    }
+    return fallback;
+  }
 
   /// Busca o nome do usuário na coleção 'users' do Firestore.
   Future<void> loadUserName() async {
@@ -157,6 +170,62 @@ class SettingsController extends ChangeNotifier {
       return false;
     } finally {
       isUploadingPhoto = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadMfaStatus() async {
+    final token = await currentUser?.getIdToken();
+    if (token == null) return;
+
+    try {
+      // Busca no backend (Firestore) se o usuario tem MFA habilitado.
+      final response = await _dio.get(
+        '/mfa/status',
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+
+      final data = response.data;
+      mfaEnabled = data is Map ? data['enabled'] == true : false;
+      notifyListeners();
+    } catch (error) {
+      debugPrint('SettingsController loadMfaStatus error: $error');
+    }
+  }
+
+  Future<bool> setMfaEnabled(bool enabled) async {
+    final token = await currentUser?.getIdToken();
+    if (token == null) return false;
+
+    // Otimista: atualiza o switch imediatamente e reverte se o backend falhar.
+    final previous = mfaEnabled;
+    mfaEnabled = enabled;
+    isUpdatingMfa = true;
+    notifyListeners();
+
+    try {
+      // Persiste no backend para garantir que o login saiba se deve exigir MFA.
+      await _dio.post(
+        enabled ? '/mfa/enable' : '/mfa/disable',
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+      return true;
+    } on DioException catch (e) {
+      // Falhou no backend: desfaz a mudança local para manter consistencia.
+      mfaEnabled = previous;
+      debugPrint(
+        _parseApiMessage(
+          e.response?.data,
+          fallback: 'Erro ao atualizar MFA.',
+        ),
+      );
+      return false;
+    } catch (error) {
+      mfaEnabled = previous;
+      debugPrint('SettingsController setMfaEnabled error: $error');
+      return false;
+    } finally {
+      isUpdatingMfa = false;
       notifyListeners();
     }
   }

--- a/flutter_client/lib/modules/presentation/pages/settings_page/settings_page.dart
+++ b/flutter_client/lib/modules/presentation/pages/settings_page/settings_page.dart
@@ -22,8 +22,6 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   late final SettingsController _controller;
 
-  bool _mfaEnabled = false;
-
   @override
   void initState() {
     super.initState();
@@ -31,6 +29,7 @@ class _SettingsPageState extends State<SettingsPage> {
     _controller = SettingsController(homeController);
     _controller.addListener(_refresh);
     _controller.loadUserName();
+    _controller.loadMfaStatus();
   }
 
   @override
@@ -188,9 +187,22 @@ class _SettingsPageState extends State<SettingsPage> {
                 iconColor: HomePalette.brandPink,
                 label: 'Autenticação multifator',
                 trailing: CupertinoSwitch(
-                  value: _mfaEnabled,
+                  value: _controller.mfaEnabled,
                   activeColor: HomePalette.brandPink,
-                  onChanged: (v) => setState(() => _mfaEnabled = v),
+                  onChanged: _controller.isUpdatingMfa
+                      ? null
+                      : (v) async {
+                          final success = await _controller.setMfaEnabled(v);
+                          if (!mounted) return;
+
+                          _showSnackBar(
+                            success
+                                ? (v
+                                      ? 'Autenticação multifator ativada.'
+                                      : 'Autenticação multifator desativada.')
+                                : 'Erro ao atualizar autenticação multifator.',
+                          );
+                        },
                 ),
               ),
               const _SettingsDivider(),

--- a/flutter_client/lib/shared/app_routes.dart
+++ b/flutter_client/lib/shared/app_routes.dart
@@ -9,6 +9,7 @@ class AppRoutes {
   static const String register = '/register';
   static const String forgotPassword = '/forgot-password';
   static const String changePassword = '/change-password';
+  static const String mfaVerify = '/mfa-verify';
   static const String allInvestments = '/all-investments';
   static const String startupDetailsPage = '/startup-details';
   static const String marketplace = '/marketplace';

--- a/flutter_client/scripts/run_chrome_emulator.cmd
+++ b/flutter_client/scripts/run_chrome_emulator.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+
+cd /d "%~dp0.."
+
+set "API_BASE_URL=http://127.0.0.1:5002/projetointegrador3-grupo18/southamerica-east1/api/"
+echo Running Flutter on Chrome with API_BASE_URL=%API_BASE_URL%
+
+call flutter run -d chrome --dart-define=API_BASE_URL=%API_BASE_URL%
+
+endlocal
+

--- a/flutter_client/scripts/run_chrome_emulator.ps1
+++ b/flutter_client/scripts/run_chrome_emulator.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location (Split-Path $PSScriptRoot -Parent)
+
+$baseUrl = "http://127.0.0.1:5002/projetointegrador3-grupo18/southamerica-east1/api/"
+
+Write-Host "Running Flutter on Chrome with API_BASE_URL=$baseUrl" -ForegroundColor Cyan
+flutter run -d chrome --dart-define=API_BASE_URL=$baseUrl
+

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 *.local
 
 serviceAccount.json
+local-mail.config.json

--- a/functions/src/domains/auth/handlers/disableMfaHandler.ts
+++ b/functions/src/domains/auth/handlers/disableMfaHandler.ts
@@ -1,0 +1,34 @@
+/*
+feito por Abdallah
+RA: 25018711
+*/
+
+import type {Request, Response} from "express";
+import * as logger from "firebase-functions/logger";
+import {isAppError} from "../../../shared/errors";
+import {disableMfa} from "../services/mfaService";
+
+export async function disableMfaHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  const uid = String((res.locals as {authenticatedUserId?: unknown}).authenticatedUserId ?? "");
+
+  if (!uid) {
+    res.status(401).json({message: "Usuario nao autenticado."});
+    return;
+  }
+
+  try {
+    const response = await disableMfa(uid);
+    res.status(200).json(response);
+  } catch (error) {
+    if (isAppError(error)) {
+      res.status(error.status).json({message: error.message});
+      return;
+    }
+
+    logger.error("Erro ao desativar MFA.", error);
+    res.status(500).json({message: "Erro ao desativar MFA."});
+  }
+}

--- a/functions/src/domains/auth/handlers/enableMfaHandler.ts
+++ b/functions/src/domains/auth/handlers/enableMfaHandler.ts
@@ -1,0 +1,34 @@
+/*
+feito por Abdallah
+RA: 25018711
+*/
+
+import type {Request, Response} from "express";
+import * as logger from "firebase-functions/logger";
+import {isAppError} from "../../../shared/errors";
+import {enableMfa} from "../services/mfaService";
+
+export async function enableMfaHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  const uid = String((res.locals as {authenticatedUserId?: unknown}).authenticatedUserId ?? "");
+
+  if (!uid) {
+    res.status(401).json({message: "Usuario nao autenticado."});
+    return;
+  }
+
+  try {
+    const response = await enableMfa(uid);
+    res.status(200).json(response);
+  } catch (error) {
+    if (isAppError(error)) {
+      res.status(error.status).json({message: error.message});
+      return;
+    }
+
+    logger.error("Erro ao ativar MFA.", error);
+    res.status(500).json({message: "Erro ao ativar MFA."});
+  }
+}

--- a/functions/src/domains/auth/handlers/getMfaStatusHandler.ts
+++ b/functions/src/domains/auth/handlers/getMfaStatusHandler.ts
@@ -1,0 +1,34 @@
+/*
+feito por Abdallah
+RA: 25018711
+*/
+
+import type {Request, Response} from "express";
+import * as logger from "firebase-functions/logger";
+import {isAppError} from "../../../shared/errors";
+import {getMfaStatus} from "../services/mfaService";
+
+export async function getMfaStatusHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  const uid = String((res.locals as {authenticatedUserId?: unknown}).authenticatedUserId ?? "");
+
+  if (!uid) {
+    res.status(401).json({message: "Usuario nao autenticado."});
+    return;
+  }
+
+  try {
+    const status = await getMfaStatus(uid);
+    res.status(200).json(status);
+  } catch (error) {
+    if (isAppError(error)) {
+      res.status(error.status).json({message: error.message});
+      return;
+    }
+
+    logger.error("Erro ao buscar status do MFA.", error);
+    res.status(500).json({message: "Erro ao buscar status do MFA."});
+  }
+}

--- a/functions/src/domains/auth/handlers/requestMfaLoginCodeHandler.ts
+++ b/functions/src/domains/auth/handlers/requestMfaLoginCodeHandler.ts
@@ -1,0 +1,34 @@
+/*
+feito por Abdallah
+RA: 25018711
+*/
+
+import type {Request, Response} from "express";
+import * as logger from "firebase-functions/logger";
+import {isAppError} from "../../../shared/errors";
+import {requestMfaLoginCode} from "../services/mfaService";
+
+export async function requestMfaLoginCodeHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  const uid = String((res.locals as {authenticatedUserId?: unknown}).authenticatedUserId ?? "");
+
+  if (!uid) {
+    res.status(401).json({message: "Usuario nao autenticado."});
+    return;
+  }
+
+  try {
+    const response = await requestMfaLoginCode(uid);
+    res.status(200).json(response);
+  } catch (error) {
+    if (isAppError(error)) {
+      res.status(error.status).json({message: error.message});
+      return;
+    }
+
+    logger.error("Erro ao enviar codigo de MFA.", error);
+    res.status(500).json({message: "Erro ao enviar codigo de MFA."});
+  }
+}

--- a/functions/src/domains/auth/handlers/verifyMfaLoginCodeHandler.ts
+++ b/functions/src/domains/auth/handlers/verifyMfaLoginCodeHandler.ts
@@ -1,0 +1,41 @@
+/*
+feito por Abdallah
+RA: 25018711
+*/
+
+import type {Request, Response} from "express";
+import * as logger from "firebase-functions/logger";
+import {isAppError} from "../../../shared/errors";
+import {verifyMfaLoginCode} from "../services/mfaService";
+
+export async function verifyMfaLoginCodeHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const uid = String((res.locals as {authenticatedUserId?: unknown}).authenticatedUserId ?? "");
+
+  if (!uid) {
+    res.status(401).json({message: "Usuario nao autenticado."});
+    return;
+  }
+
+  const code = String(req.body?.code ?? "").trim();
+
+  if (!code) {
+    res.status(400).json({message: "code e obrigatorio."});
+    return;
+  }
+
+  try {
+    const response = await verifyMfaLoginCode(uid, code);
+    res.status(200).json(response);
+  } catch (error) {
+    if (isAppError(error)) {
+      res.status(error.status).json({message: error.message});
+      return;
+    }
+
+    logger.error("Erro ao verificar codigo de MFA.", error);
+    res.status(500).json({message: "Erro ao verificar codigo de MFA."});
+  }
+}

--- a/functions/src/domains/auth/index.ts
+++ b/functions/src/domains/auth/index.ts
@@ -2,11 +2,23 @@ import express from "express";
 import {forgotPasswordHandler} from "./handlers/forgotPasswordHandler";
 import {resetPasswordHandler} from "./handlers/resetPasswordHandler";
 import {verifyResetCodeHandler} from "./handlers/verifyResetCodeHandler";
+import {requireAuthenticatedUser} from "../../middlewares/authMiddleware";
+import {getMfaStatusHandler} from "./handlers/getMfaStatusHandler";
+import {enableMfaHandler} from "./handlers/enableMfaHandler";
+import {disableMfaHandler} from "./handlers/disableMfaHandler";
+import {requestMfaLoginCodeHandler} from "./handlers/requestMfaLoginCodeHandler";
+import {verifyMfaLoginCodeHandler} from "./handlers/verifyMfaLoginCodeHandler";
 
 const router = express.Router();
 
 router.post("/forgot-password", forgotPasswordHandler);
 router.post("/verify-reset-code", verifyResetCodeHandler);
 router.post("/reset-password", resetPasswordHandler);
+
+router.get("/mfa/status", requireAuthenticatedUser, getMfaStatusHandler);
+router.post("/mfa/enable", requireAuthenticatedUser, enableMfaHandler);
+router.post("/mfa/disable", requireAuthenticatedUser, disableMfaHandler);
+router.post("/mfa/request-code", requireAuthenticatedUser, requestMfaLoginCodeHandler);
+router.post("/mfa/verify-code", requireAuthenticatedUser, verifyMfaLoginCodeHandler);
 
 export default router;

--- a/functions/src/domains/auth/repositories/mailRepository.ts
+++ b/functions/src/domains/auth/repositories/mailRepository.ts
@@ -53,3 +53,43 @@ export async function sendPasswordResetEmail(
 
   return true;
 }
+
+export async function sendMfaLoginCodeEmail(
+  to: string,
+  code: string,
+): Promise<boolean> {
+  const localMailConfig = loadLocalMailConfig();
+  const mailUser = process.env.MAIL_USER || localMailConfig.mailUser;
+  const mailPass = process.env.MAIL_PASS || localMailConfig.mailPass;
+
+  if (!mailUser || !mailPass) {
+    logger.warn(
+      "MAIL_USER/MAIL_PASS nao configurados. O envio de e-mail de MFA nao foi realizado.",
+    );
+    return false;
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: "smtp.gmail.com",
+    port: 587,
+    secure: false,
+    auth: {
+      user: mailUser,
+      pass: mailPass,
+    },
+  });
+
+  await transporter.sendMail({
+    from: `"MesclaInvest" <${mailUser}>`,
+    to,
+    subject: "Codigo de verificacao (2 etapas)",
+    html: `
+      <h2>Autenticacao em duas etapas</h2>
+      <p>Use o codigo abaixo para concluir o login:</p>
+      <h1 style="letter-spacing:4px">${code}</h1>
+      <p>Se voce nao reconhece essa tentativa, altere sua senha.</p>
+    `,
+  });
+
+  return true;
+}

--- a/functions/src/domains/auth/repositories/mfaRepository.ts
+++ b/functions/src/domains/auth/repositories/mfaRepository.ts
@@ -1,0 +1,63 @@
+/*
+feito por Abdallah
+RA: 25018711
+*/
+
+import {db} from "../../../shared/firebase";
+import type {StoredMfaCode} from "../../../shared/types";
+
+const usersCollection = "users";
+const mfaCodesCollection = "mfaLoginCodes";
+
+export async function readUserMfaEnabled(uid: string): Promise<boolean> {
+  // O status do MFA fica no perfil do usuario em /users/{uid}.
+  const snapshot = await db.collection(usersCollection).doc(uid).get();
+
+  if (!snapshot.exists) {
+    return false;
+  }
+
+  return snapshot.data()?.mfaEnabled === true;
+}
+
+export async function setUserMfaEnabled(
+  uid: string,
+  enabled: boolean,
+): Promise<void> {
+  await db
+    .collection(usersCollection)
+    .doc(uid)
+    .set(
+      {
+        mfaEnabled: enabled,
+        mfaUpdatedAt: new Date().toISOString(),
+      },
+      {merge: true},
+    );
+}
+
+export async function readMfaCode(uid: string): Promise<StoredMfaCode | null> {
+  // O codigo do MFA fica separado em /mfaLoginCodes/{uid} para ser facilmente
+  // invalidado (delete) apos uso/expiracao.
+  const snapshot = await db.collection(mfaCodesCollection).doc(uid).get();
+
+  if (!snapshot.exists) {
+    return null;
+  }
+
+  return snapshot.data() as StoredMfaCode;
+}
+
+export async function storeMfaCode(record: StoredMfaCode): Promise<void> {
+  await db
+    .collection(mfaCodesCollection)
+    .doc(record.uid)
+    .set({
+      ...record,
+      updatedAt: new Date().toISOString(),
+    });
+}
+
+export async function clearMfaCode(uid: string): Promise<void> {
+  await db.collection(mfaCodesCollection).doc(uid).delete();
+}

--- a/functions/src/domains/auth/services/mfaService.ts
+++ b/functions/src/domains/auth/services/mfaService.ts
@@ -1,0 +1,120 @@
+/*
+feito por Abdallah
+RA: 25018711
+*/
+
+import {createAppError} from "../../../shared/errors";
+import {auth} from "../../../shared/firebase";
+import type {StoredMfaCode} from "../../../shared/types";
+import {
+  createFutureIsoString,
+  generateVerificationCode,
+  isExpired,
+} from "../../../shared/utils";
+import {sendMfaLoginCodeEmail} from "../repositories/mailRepository";
+import {
+  clearMfaCode,
+  readMfaCode,
+  readUserMfaEnabled,
+  setUserMfaEnabled,
+  storeMfaCode,
+} from "../repositories/mfaRepository";
+
+const mfaCodeExpiresInMinutes = 10;
+
+export async function getMfaStatus(
+  uid: string,
+): Promise<{enabled: boolean}> {
+  const enabled = await readUserMfaEnabled(uid);
+  return {enabled};
+}
+
+export async function enableMfa(uid: string): Promise<{message: string}> {
+  await setUserMfaEnabled(uid, true);
+  return {message: "MFA ativado com sucesso."};
+}
+
+export async function disableMfa(uid: string): Promise<{message: string}> {
+  await setUserMfaEnabled(uid, false);
+  await clearMfaCode(uid);
+  return {message: "MFA desativado com sucesso."};
+}
+
+export async function requestMfaLoginCode(
+  uid: string,
+): Promise<{message: string}> {
+  const enabled = await readUserMfaEnabled(uid);
+
+  if (!enabled) {
+    throw createAppError(400, "MFA nao esta habilitado para este usuario.");
+  }
+
+  // O uid vem do token Firebase do usuario (middleware).
+  // Buscamos o e-mail direto no Firebase Auth para evitar confiar em
+  // dados enviados pelo cliente.
+  const userRecord = await auth.getUser(uid);
+  const email = userRecord.email?.trim().toLowerCase();
+
+  if (!email) {
+    throw createAppError(400, "Usuario nao possui e-mail cadastrado.");
+  }
+
+  // Gera um codigo de 6 digitos e persiste no Firestore com expiracao.
+  // O codigo fica associado ao uid (1 codigo valido por usuario por vez).
+  const code = generateVerificationCode();
+  const expiresAt = createFutureIsoString(mfaCodeExpiresInMinutes);
+
+  const record: StoredMfaCode = {
+    code,
+    email,
+    expiresAt,
+    uid,
+  };
+
+  await storeMfaCode(record);
+
+  const emailSent = await sendMfaLoginCodeEmail(email, code);
+
+  if (!emailSent) {
+    await clearMfaCode(uid);
+    throw createAppError(
+      503,
+      "Nao foi possivel enviar o codigo de verificacao. Tente novamente em instantes.",
+    );
+  }
+
+  return {message: "Codigo enviado para o e-mail cadastrado."};
+}
+
+export async function verifyMfaLoginCode(
+  uid: string,
+  code: string,
+): Promise<{message: string}> {
+  const enabled = await readUserMfaEnabled(uid);
+
+  if (!enabled) {
+    throw createAppError(400, "MFA nao esta habilitado para este usuario.");
+  }
+
+  const record = await readMfaCode(uid);
+
+  if (!record) {
+    throw createAppError(400, "Codigo de verificacao invalido.");
+  }
+
+  // Compara o codigo e valida expiracao.
+  // Se expirar ou for consumido, o registro e removido para impedir reuse.
+  if (record.code !== code) {
+    throw createAppError(400, "Codigo de verificacao invalido.");
+  }
+
+  if (isExpired(record.expiresAt)) {
+    await clearMfaCode(uid);
+    throw createAppError(400, "Codigo expirado. Solicite um novo codigo.");
+  }
+
+  // Codigo consumido: remove do Firestore e libera o login.
+  await clearMfaCode(uid);
+
+  return {message: "Login verificado com sucesso."};
+}

--- a/functions/src/domains/users/repositories/userRepository.ts
+++ b/functions/src/domains/users/repositories/userRepository.ts
@@ -19,6 +19,7 @@ type UserProfilePayload = {
   cpf: string;
   createdAt: Date;
   email: string;
+  mfaEnabled?: boolean;
   nome: string;
   telefone: string;
 };

--- a/functions/src/domains/users/services/createUserService.ts
+++ b/functions/src/domains/users/services/createUserService.ts
@@ -33,6 +33,7 @@ export async function createUser(data: CreateUserInput): Promise<UserRecord> {
     cpf,
     telefone,
     email,
+    mfaEnabled: false,
     createdAt: new Date(),
   });
 

--- a/functions/src/shared/types.ts
+++ b/functions/src/shared/types.ts
@@ -11,6 +11,14 @@ export type StoredResetCode = {
   updatedAt?: string;
 };
 
+export type StoredMfaCode = {
+  code: string;
+  email: string;
+  expiresAt: string;
+  uid: string;
+  updatedAt?: string;
+};
+
 export type CreateUserInput = {
   cpf?: string;
   email?: string;

--- a/scripts/dev-mfa-emulator.cmd
+++ b/scripts/dev-mfa-emulator.cmd
@@ -1,0 +1,18 @@
+@echo off
+setlocal
+
+cd /d "%~dp0.."
+
+echo Installing backend deps (functions)...
+call npm.cmd --prefix functions install
+if errorlevel 1 exit /b 1
+
+echo Building backend (functions)...
+call npm.cmd --prefix functions run build
+if errorlevel 1 exit /b 1
+
+echo Starting Firebase emulators (firestore,functions)...
+call firebase.cmd emulators:start --only firestore,functions
+
+endlocal
+

--- a/scripts/dev-mfa-emulator.ps1
+++ b/scripts/dev-mfa-emulator.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location (Split-Path $PSScriptRoot -Parent)
+
+Write-Host "Installing backend deps (functions)..." -ForegroundColor Cyan
+npm.cmd --prefix functions install
+
+Write-Host "Building backend (functions)..." -ForegroundColor Cyan
+npm.cmd --prefix functions run build
+
+Write-Host "Starting Firebase emulators (firestore,functions)..." -ForegroundColor Cyan
+firebase.cmd emulators:start --only firestore,functions


### PR DESCRIPTION
Implementa autenticação em duas etapas (MFA) via código enviado por e-mail.
Ao ativar “Autenticação multifator” em Configurações, o app passa a exigir um código de 6 dígitos após o login: o backend gera o código, salva temporariamente no Firestore com expiração e envia por e-mail; o usuário confirma o código na nova tela /mfa-verify para acessar a conta. Inclui endpoints de status/enable/disable 

Feito em 6 horas